### PR TITLE
Error messages bug fix

### DIFF
--- a/src/_tictactoe/console_io.clj
+++ b/src/_tictactoe/console_io.clj
@@ -21,7 +21,7 @@
 (defn colorize-markers [row]
   (map (fn [spot]
         (if (number? spot) (str (get colors :cyan) spot (get colors :end-marker))
-            (str (get colors :red) spot (get colors :end-marker)))) 
+            (str (get colors :red) spot (get colors :end-marker))))
         row))
 
 (defn print-row [row]
@@ -62,10 +62,12 @@
   (println "Please input spot to be marked. Must be 0 -" (dec (count board)) "and open.")
   (loop [spot (convert-string-to-number (read-line))
          board board]
-    (if (check-if-spot-is-not-open board spot)
-      (do
-        (println "Spot must be open.")
-        (recur (convert-string-to-number (read-line)) board))
+    (if (check-if-spot-is-invalid board spot)
+      (do (cond (check-if-spot-is-invalid-input board spot) (println "Spot must be an integer corresponding to an open location.")
+                (check-if-spot-is-not-on-board board spot) (println "Spot must be a location on the game board.")
+                (check-if-spot-is-already-marked board spot) (println "Spot must be open and unmarked.")
+                :else (println "That spot is not valid."))
+          (recur (convert-string-to-number (read-line)) board))
       spot)))
 
 (defn get-player-one-name []

--- a/src/_tictactoe/input_validation.clj
+++ b/src/_tictactoe/input_validation.clj
@@ -15,6 +15,15 @@
   (and (not (= first-player-marker player-one-marker))
        (not (= first-player-marker player-two-marker))))
 
-(defn check-if-spot-is-not-open [board spot]
+(defn check-if-spot-is-invalid-input [board spot]
+  (nil? spot))
+
+(defn check-if-spot-is-already-marked [board spot]
+  (string? (get board spot)))
+
+(defn check-if-spot-is-not-on-board [board spot]
+  (nil? (find board spot)))
+
+(defn check-if-spot-is-invalid [board spot]
   (or (nil? (find board spot))
       (not  (number? (get board spot)))))

--- a/target/classes/META-INF/maven/-tictactoe/-tictactoe/pom.properties
+++ b/target/classes/META-INF/maven/-tictactoe/-tictactoe/pom.properties
@@ -1,6 +1,6 @@
 #Leiningen
-#Mon Mar 07 06:22:35 CST 2016
+#Mon Mar 07 09:25:59 CST 2016
 version=0.1.0-SNAPSHOT
-revision=664c3bbd663b4cd56fdef8b373eb0257101c46c5\n
+revision=8868e609a72e4bda99a633b0067e52b43d7b5df6\n
 groupId=-tictactoe
 artifactId=-tictactoe


### PR DESCRIPTION
Changed error messages to be more descriptive when inputting a spot
value that is not valid. Broke down the methods that check the spot for
whether it is on the board, not a number, or a spot that is already
taken in order to display the correct error messages.
